### PR TITLE
Renaming zed2i node from "zed2i" to "zed2i_driver_node"

### DIFF
--- a/box_bringup/bringup_zed2i/launch/zed2i.launch
+++ b/box_bringup/bringup_zed2i/launch/zed2i.launch
@@ -25,7 +25,7 @@ This is based on box_drivers/zed-ros-wrapper/zed_wrapper/launch/include/zed_came
         <!-- Camera Model and Name -->
         <arg name="camera_name"           default="zed2i" />
         <arg name="camera_model"          default="zed2i" />
-        <arg name="node_name"             default="zed2i" />
+        <arg name="node_name"             default="zed2i_driver_node" />
 
         <!-- Load SVO file -->
         <arg name="svo_file"              default="" /><!-- <arg name="svo_file" default="path/to/svo/file.svo"> -->

--- a/box_utils/box_calibration/calib_importer.py
+++ b/box_utils/box_calibration/calib_importer.py
@@ -32,8 +32,8 @@ class TopicMap:
     ALPHASENSE_FRONT_LEFT_TO_ALPHASENSE_FRONT_MIDDLE = "/gt_box/alphasense_driver_node/cam2/color/image"
     ALPHASENSE_FRONT_LEFT_TO_ALPHASENSE_LEFT = "/gt_box/alphasense_driver_node/cam3/color/image"
     ALPHASENSE_FRONT_LEFT_TO_ALPHASENSE_RIGHT = "/gt_box/alphasense_driver_node/cam4/color/image"
-    ALPHASENSE_FRONT_LEFT_TO_ZED_LEFT = "/gt_box/zed2i/zed_node/left_raw/image_raw_color"
-    ALPHASENSE_FRONT_LEFT_TO_ZED_RIGHT = "/gt_box/zed2i/zed_node/right_raw/image_raw_color"
+    ALPHASENSE_FRONT_LEFT_TO_ZED_LEFT = "/gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color"
+    ALPHASENSE_FRONT_LEFT_TO_ZED_RIGHT = "/gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color"
 
 
 def inverse_transform(T):

--- a/box_utils/box_calibration/calibration_input_data/camera-extrinsics.yaml
+++ b/box_utils/box_calibration/calibration_input_data/camera-extrinsics.yaml
@@ -83,7 +83,7 @@
   - 0.0
   - 0.0
   - 1.0
-/gt_box/zed2i/zed_node/left_raw/image_raw_color:
+/gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color:
 - - -0.9999969500698463
   - 0.002374958886580617
   - 0.0006778062350397705
@@ -100,7 +100,7 @@
   - 0.0
   - 0.0
   - 1.0
-/gt_box/zed2i/zed_node/rgb_raw/image_raw_color:
+/gt_box/zed2i_driver_node/zed_node/rgb_raw/image_raw_color:
 - - -0.9999955429334562
   - 0.002410244918977951
   - 0.0017620535328848668
@@ -117,7 +117,7 @@
   - 0.0
   - 0.0
   - 1.0
-/gt_box/zed2i/zed_node/right_raw/image_raw_color:
+/gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color:
 - - -0.9999818961409659
   - 0.00501225056784999
   - 0.003329374500362103

--- a/box_utils/box_health/cfg/health_check_topics.yaml
+++ b/box_utils/box_health/cfg/health_check_topics.yaml
@@ -11,10 +11,10 @@ jetson:
   - /gt_box/livox/imu
   - /gt_box/alphasense_driver_node/imu
   - /gt_box/rover/piksi/position_receiver_0/ros/pos_enu
-  - /gt_box/zed2i/zed_node/point_cloud/cloud_registered
-  - /gt_box/zed2i/zed_node/left_raw/image_raw_color
-  - /gt_box/zed2i/zed_node/right_raw/image_raw_color
-  - /gt_box/zed2i/zed_node/depth/depth_registered
+  - /gt_box/zed2i_driver_node/zed_node/point_cloud/cloud_registered
+  - /gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color
+  - /gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color
+  - /gt_box/zed2i_driver_node/zed_node/depth/depth_registered
   - /gt_box/ap20_imu
   - /gt_box/ap20_prism_position
 nuc:

--- a/box_utils/box_recording/cfg/box_default.yaml
+++ b/box_utils/box_recording/cfg/box_default.yaml
@@ -20,20 +20,20 @@ jetson:
     - /gt_box/alphasense_driver_node/imu
     - /gt_box/health_status/jetson
   zed2i:
-    - /gt_box/zed2i/temperature/imu
-    - /gt_box/zed2i/temperature/left
-    - /gt_box/zed2i/temperature/right
-    - /gt_box/zed2i/confidence/confidence_map
-    - /gt_box/zed2i/depth/depth_registered
-    - /gt_box/zed2i/imu/data
-    - /gt_box/zed2i/imu/data_raw
-    - /gt_box/zed2i/imu/mag
-    - /gt_box/zed2i/odom
-    - /gt_box/zed2i/odom/status
-    - /gt_box/zed2i/point_cloud/cloud_registered
-    - /gt_box/zed2i/rgb_raw/image_raw_color/compressed
-    - /gt_box/zed2i/left_raw/image_raw_color/compressed
-    - /gt_box/zed2i/right_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/temperature/imu
+    - /gt_box/zed2i_driver_node/temperature/left
+    - /gt_box/zed2i_driver_node/temperature/right
+    - /gt_box/zed2i_driver_node/confidence/confidence_map
+    - /gt_box/zed2i_driver_node/depth/depth_registered
+    - /gt_box/zed2i_driver_node/imu/data
+    - /gt_box/zed2i_driver_node/imu/data_raw
+    - /gt_box/zed2i_driver_node/imu/mag
+    - /gt_box/zed2i_driver_node/odom
+    - /gt_box/zed2i_driver_node/odom/status
+    - /gt_box/zed2i_driver_node/point_cloud/cloud_registered
+    - /gt_box/zed2i_driver_node/rgb_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/left_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/right_raw/image_raw_color/compressed
   ap20:
     - /gt_box/ap20/ap20_imu
     - /gt_box/ap20/prism_position

--- a/box_utils/box_recording/cfg/box_uncompressed.yaml
+++ b/box_utils/box_recording/cfg/box_uncompressed.yaml
@@ -30,17 +30,17 @@ jetson:
     - /gt_box/rover/piksi/position_receiver_0/ros/time_ref
     - /gt_box/rover/piksi_reference/position_receiver_0/ros/baseline_ned
   zed2i:
-    - /gt_box/zed2i/joint_states
-    - /gt_box/zed2i/zed_node/confidence/confidence_map
-    - /gt_box/zed2i/zed_node/depth/depth_registered
-    - /gt_box/zed2i/zed_node/imu/data
-    - /gt_box/zed2i/zed_node/imu/data_raw
-    - /gt_box/zed2i/zed_node/odom
-    - /gt_box/zed2i/zed_node/odom/status
-    - /gt_box/zed2i/zed_node/point_cloud/cloud_registered
-    - /gt_box/zed2i/zed_node/rgb_raw/image_raw_color
-    - /gt_box/zed2i/zed_node/left_raw/image_raw_color
-    - /gt_box/zed2i/zed_node/right_raw/image_raw_color
+    - /gt_box/zed2i_driver_node/joint_states
+    - /gt_box/zed2i_driver_node/zed_node/confidence/confidence_map
+    - /gt_box/zed2i_driver_node/zed_node/depth/depth_registered
+    - /gt_box/zed2i_driver_node/zed_node/imu/data
+    - /gt_box/zed2i_driver_node/zed_node/imu/data_raw
+    - /gt_box/zed2i_driver_node/zed_node/odom
+    - /gt_box/zed2i_driver_node/zed_node/odom/status
+    - /gt_box/zed2i_driver_node/zed_node/point_cloud/cloud_registered
+    - /gt_box/zed2i_driver_node/zed_node/rgb_raw/image_raw_color
+    - /gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color
+    - /gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color
   ap20:
     - /gt_box/ap20_imu
     - /gt_box/ap20_prism_position

--- a/box_utils/box_recording/cfg/calib_camera_front.yaml
+++ b/box_utils/box_recording/cfg/calib_camera_front.yaml
@@ -4,9 +4,9 @@ jetson:
     - /gt_box/alphasense_driver_node/cam1/compressed
     - /gt_box/alphasense_driver_node/cam2/compressed
   zed2i:
-    - /gt_box/zed2i/zed_node/rgb_raw/image_raw_color/compressed
-    - /gt_box/zed2i/zed_node/left_raw/image_raw_color/compressed
-    - /gt_box/zed2i/zed_node/right_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/rgb_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color/compressed
   utils:
     - /gt_box/health_status/jetson
 nuc:

--- a/box_utils/box_recording/cfg/calib_camera_front_imu.yaml
+++ b/box_utils/box_recording/cfg/calib_camera_front_imu.yaml
@@ -4,9 +4,9 @@ jetson:
     - /gt_box/alphasense_driver_node/cam1/compressed
     - /gt_box/alphasense_driver_node/cam2/compressed
   zed2i:
-    - /gt_box/zed2i/zed_node/rgb_raw/image_raw_color/compressed
-    - /gt_box/zed2i/zed_node/left_raw/image_raw_color/compressed
-    - /gt_box/zed2i/zed_node/right_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/rgb_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color/compressed
   utils:
     - /gt_box/health_status/jetson
     - /gt_box/alphasense_driver_node/aux_imu

--- a/box_utils/box_recording/cfg/calib_camera_front_lidar.yaml
+++ b/box_utils/box_recording/cfg/calib_camera_front_lidar.yaml
@@ -4,9 +4,9 @@ jetson:
     - /gt_box/alphasense_driver_node/cam1/compressed
     - /gt_box/alphasense_driver_node/cam2/compressed
   zed2i:
-    - /gt_box/zed2i/zed_node/rgb_raw/image_raw_color/compressed
-    - /gt_box/zed2i/zed_node/left_raw/image_raw_color/compressed
-    - /gt_box/zed2i/zed_node/right_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/rgb_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/left_raw/image_raw_color/compressed
+    - /gt_box/zed2i_driver_node/zed_node/right_raw/image_raw_color/compressed
   hesai:
     - /gt_box/hesai/points
   livox:

--- a/box_utils/box_rviz/cfg/config.rviz
+++ b/box_utils/box_rviz/cfg/config.rviz
@@ -985,7 +985,7 @@ Visualization Manager:
       Displays:
         - Class: rviz/Image
           Enabled: true
-          Image Topic: /gt_box/throttled/gt_box/zed2i/left/image_rect_color
+          Image Topic: /gt_box/throttled/gt_box/zed2i_driver_node/left/image_rect_color
           Max Value: 1
           Median window: 5
           Min Value: 0
@@ -997,7 +997,7 @@ Visualization Manager:
           Value: true
         - Class: rviz/Image
           Enabled: true
-          Image Topic: /gt_box/throttled/gt_box/zed2i/left/image_rect_color
+          Image Topic: /gt_box/throttled/gt_box/zed2i_driver_node/left/image_rect_color
           Max Value: 1
           Median window: 5
           Min Value: 0
@@ -1030,7 +1030,7 @@ Visualization Manager:
           Size (Pixels): 3
           Size (m): 0.009999999776482582
           Style: Flat Squares
-          Topic: /gt_box/throttled/zed2i/point_cloud/cloud_registered
+          Topic: /gt_box/throttled/zed2i_driver_node/point_cloud/cloud_registered
           Unreliable: false
           Use Fixed Frame: true
           Use rainbow: true

--- a/box_utils/box_throttling/launch/throttle_jetson.launch
+++ b/box_utils/box_throttling/launch/throttle_jetson.launch
@@ -37,15 +37,15 @@
       <param name="capability_group" value="Throttling"/>
     </node>
     
-    <node name="zed_left_throttler" type="throttle" pkg="topic_tools" args="messages /gt_box/zed2i/left/image_rect_color/compressed $(arg zed2i_frequency) /gt_box/throttled/gt_box/zed2i/left/image_rect_color/compressed"> 
+    <node name="zed_left_throttler" type="throttle" pkg="topic_tools" args="messages /gt_box/zed2i_driver_node/left/image_rect_color/compressed $(arg zed2i_frequency) /gt_box/throttled/gt_box/zed2i_driver_node/left/image_rect_color/compressed"> 
       <param name="capability_group" value="Throttling"/>
     </node>
     
-    <node name="zed_right_throttler" type="throttle" pkg="topic_tools" args="messages /gt_box/zed2i/right/image_rect_color/compressed $(arg zed2i_frequency) /gt_box/throttled/gt_box/zed2i/right/image_rect_color/compressed"> 
+    <node name="zed_right_throttler" type="throttle" pkg="topic_tools" args="messages /gt_box/zed2i_driver_node/right/image_rect_color/compressed $(arg zed2i_frequency) /gt_box/throttled/gt_box/zed2i_driver_node/right/image_rect_color/compressed"> 
       <param name="capability_group" value="Throttling"/>
     </node>
     
-    <node name="zed_pointcloud_throttler" type="throttle" pkg="topic_tools" args="messages /gt_box/zed2i/point_cloud/cloud_registered $(arg zed2i_frequency) /gt_box/throttled/zed2i/point_cloud/cloud_registered" > 
+    <node name="zed_pointcloud_throttler" type="throttle" pkg="topic_tools" args="messages /gt_box/zed2i_driver_node/point_cloud/cloud_registered $(arg zed2i_frequency) /gt_box/throttled/zed2i_driver_node/point_cloud/cloud_registered" > 
       <param name="capability_group" value="Throttling"/>
     </node>
     


### PR DESCRIPTION
Fixes #319
This fixes a namespace collision that was preventing the zed2i tf being published on startup. Also this now follows the naming convention of the other driver nodes.