### PR TITLE
Correct default CAD alphasense IMU orientation

### DIFF
--- a/box_model/box_model/urdf/box/calibrations/calibration.yaml
+++ b/box_model/box_model/urdf/box/calibrations/calibration.yaml
@@ -122,7 +122,7 @@ box_base_to_imu_alphasense:
   x: 0.0
   y: 0.0
   z: 0.0
-  roll: 0.0
+  roll: 3.14159265
   pitch: 0.0
   yaw: 0.0
 


### PR DESCRIPTION
As referenced in #474, currently the default alphasense CAD IMU transform is 180 degrees flipped. This PR fixes this issue, yielding the acceleration plots we see below. Note the consistency across IMU's is way better than the state shown in #474.
![image](https://github.com/user-attachments/assets/fce51db6-7bb2-4193-bb93-8cb6caa8daf8)
