### PR TITLE
Remove large image files

### DIFF
--- a/box_model/box_model/urdf/box/box.urdf.xacro
+++ b/box_model/box_model/urdf/box/box.urdf.xacro
@@ -3,7 +3,7 @@
 <robot name="box" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 <!-- YAML file containing the default values from CAD -->
-<xacro:property name="calib_file" value="$(find box_calibration)/calibration/tf/calibration_latest.yaml" />
+<xacro:property name="calib_file" value="$(find box_calibration)/calibration/tf/calibration_cad.yaml" />
 <!-- load the YAML calibration file into a property -->
 <xacro:property name="calib" value="${xacro.load_yaml(calib_file)}"/>
 <!-- YAML file containing the default values from CAD -->
@@ -35,7 +35,7 @@
     </visual>
   </link>
   <joint name="box_base_to_box_base_model" type="fixed">
-    <origin xyz="-0.02 0.0 0.0" rpy="0.0 0.0 0.0" />
+    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
     <parent link="stim320_imu" />
     <child link="box_base_model" />
   </joint>


### PR DESCRIPTION
Currently, there's an error in the front-camera <-> CPT-7 calibration that leads to an inconsistent box model as seen below:
![image](https://github.com/user-attachments/assets/442d7c96-7522-48a8-b4ce-1b23fe3024b7)


This PR reverts to using the CAD, as shown below
![image](https://github.com/user-attachments/assets/27db9b92-feb8-48b7-a799-070a8397fa4d)
