### PR TITLE
[DRAFT] Kill hanging roscore in applications

### DIFF
--- a/box_utils/box_auto/python/box_auto/scripts/application/dlio.py
+++ b/box_utils/box_auto/python/box_auto/scripts/application/dlio.py
@@ -54,6 +54,7 @@ def launch_nodes():
     print("Waiting for 10s before uploading!")
     sleep(10)
     print("Moving and uploading bag!")
+    kill_roscore()
 
     output_bag_path = os.path.join(MISSION_DATA, f"{timestamp}_dlio.bag")
     shutil.move(f"{MISSION_DATA}/{OUTPUT_BAG_NAME}.bag", output_bag_path)

--- a/box_utils/box_auto/python/box_auto/scripts/application/open3d_slam.py
+++ b/box_utils/box_auto/python/box_auto/scripts/application/open3d_slam.py
@@ -53,6 +53,7 @@ def launch_nodes():
         background=True,
     )
     sleep(1)
+    kill_roscore()
 
     output_bag_path = os.path.join(MISSION_DATA, f"{timestamp}_open3d_slam.bag")
     shutil.move(str(Path(MISSION_DATA) / "open3d_slam_replayed.bag"), output_bag_path)


### PR DESCRIPTION
- In many cases a roscore hangs in the background in local mode. (Outside of docker)
- Spotted for DLIO and Open3d cases, needs to be double checked for rest, hence as draft