### PR TITLE
Fix the output frame names of alphasense cam1 and cam3 which were fli…

### DIFF
--- a/box_bringup/bringup_alphasense/core_research/launch/debayer_all.launch
+++ b/box_bringup/bringup_alphasense/core_research/launch/debayer_all.launch
@@ -1,10 +1,10 @@
 <launch>
 
 <include file="$(find bringup_alphasense)/launch/debayer_single_camera.launch">
-    <arg name="camera_name" value="alphasense_front_left"/>
+    <arg name="camera_name" value="alphasense_front_center"/>
     <arg name="input_topic" value="alphasense_driver_node/cam1"/>
     <arg name="output_prefix" value="alphasense_driver_node/cam1"/>
-    <arg name="output_frame" value="alphasense_front_left"/>
+    <arg name="output_frame" value="alphasense_front_center"/>
     <arg name="debayer/enabled" value="false"/>
     <arg name="white_balance/enabled" value="false"/>
     <arg name="undistortion/calibration_file" value="$(find box_calibration)/calibration/alphasense/cam1.yaml"/>
@@ -21,10 +21,10 @@
 </include>
 
 <include file="$(find bringup_alphasense)/launch/debayer_single_camera.launch">
-    <arg name="camera_name" value="alphasense_front_center"/>
+    <arg name="camera_name" value="alphasense_front_left"/>
     <arg name="input_topic" value="alphasense_driver_node/cam3"/>
     <arg name="output_prefix" value="alphasense_driver_node/cam3"/>
-    <arg name="output_frame" value="alphasense_front_center"/>
+    <arg name="output_frame" value="alphasense_front_left"/>
     <arg name="debayer/enabled" value="true"/>
     <arg name="white_balance/enabled" value="false"/>
     <arg name="undistortion/calibration_file" value="$(find box_calibration)/calibration/alphasense/cam3.yaml"/>


### PR DESCRIPTION
The frame ids set in the `debayer_all.launch` have the names of the `alphasense_front_left` and `alphasense_front_center` swapped.

The two images below show the correctly mapped calibration and calibration helper frame names, that is to say the calibration has the correct mapping between the numerically ordered image topics and the colloquial names of the camera frames.
![image](https://github.com/user-attachments/assets/d7969a7d-6e48-4706-9985-5571390f2d3d)
![image](https://github.com/user-attachments/assets/ef6cb774-29c8-4fc7-a216-218928c0af96)
The image below shows the currently incorrect frame_id assigned to the debayered topic.
![image](https://github.com/user-attachments/assets/b78eb5e6-eaaa-4454-8d03-536c4e22ab47)

The images below show the case for camera 3.
![image](https://github.com/user-attachments/assets/d0a9d9b0-723a-4bde-9ae6-e9caa4d75bb3)
![image](https://github.com/user-attachments/assets/62b9ce90-aeb4-4b7e-9ff0-1857e0bc34e5)
![image](https://github.com/user-attachments/assets/4b8288fc-2830-42e4-94a6-e3e1c2a73194)

This PR fixes the name mapping. I've verified that the other alphasense cameras are correct.
