### PR TITLE
Removing -y flag from pip3 command 

### DIFF
--- a/box_utils/box_auto/docker/dependencies/grand_tour.sh
+++ b/box_utils/box_auto/docker/dependencies/grand_tour.sh
@@ -119,7 +119,7 @@ ln -s /home/catkin_ws/src/grand_tour_box/box_bringup/bringup_hesai/config/Pandar
 ln -s /home/catkin_ws/src/grand_tour_box/box_bringup/bringup_hesai/config/PandarXT-32.csv  /home/rsl/git/grand_tour_box/box_bringup/bringup_hesai/config/PandarXT-32.csv
 
 # Dependencies: box_auto - evo_evaluation
-pip3 install fpdf -y
+pip3 install fpdf
 
 # Dependencies: direct_lidar_inertial_odometry
 apt install -y libomp-dev libpcl-dev libeigen3-dev


### PR DESCRIPTION
The -y flag is invalid for pip3. Script worked without it, failed with it.