### PR TITLE
Decompress ready

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -99,3 +99,6 @@
 	path = box_applications/gtsam_catkin
 	url = git@github.com:leggedrobotics/gtsam_catkin.git
 	branch = grandtour
+[submodule "box_utils/box_binding/external/nanobind"]
+	path = box_utils/box_binding/external/nanobind
+	url = https://github.com/wjakob/nanobind

--- a/box_utils/box_auto/python/box_auto/scripts/camera/decompress_zed2i.py
+++ b/box_utils/box_auto/python/box_auto/scripts/camera/decompress_zed2i.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+import sys
+import os
+import numpy as np
+import rosbag
+import cv2
+from tqdm import tqdm
+from box_auto.utils import get_bag
+import pathlib
+
+for parent in pathlib.Path(__file__).resolve().parents:
+    bb = parent / "box_binding"
+    if (bb / "compressed_depth").is_dir():
+        sys.path.insert(0, str(bb))
+        break
+
+import compressed_depth
+
+PRINT_VERBOSE = False
+
+
+def log(*args):
+    if PRINT_VERBOSE:
+        print(*args)
+
+
+def inspect_array(arr, label="array"):
+    if not PRINT_VERBOSE:
+        return
+    print(f"  • {label:<10} : shape={arr.shape}, dtype={arr.dtype}")
+    print(f"    ├ type      : {type(arr)}")
+    print(f"    ├ ndim      : {arr.ndim}")
+    print(f"    ├ itemsize  : {arr.itemsize}")
+    print(f"    ├ strides   : {arr.strides}")
+    print(f"    ├ size      : {arr.size}")
+    print(f"    ├ nbytes    : {arr.nbytes}")
+    print(f"    ├ flags     : {arr.flags}")
+    print(f"    └ first val : {arr.flat[0] if arr.size > 0 else 'n/a'}")
+
+
+def decode_depth_message(msg):
+    payload = np.frombuffer(msg.data, dtype=np.uint8).copy()
+    if payload.size < 20:
+        raise ValueError("Message too small (need 20+ bytes)")
+
+    header = payload[12:20]
+    cols, rows = np.frombuffer(header, dtype=np.uint32)
+    log(f"  • RVL header : {cols}×{rows}")
+
+    depth = compressed_depth.decode(payload, msg.format)
+    inspect_array(depth, "decoded")
+
+    if not depth.flags["C_CONTIGUOUS"]:
+        log("    [WARN] Not C-contiguous – copying")
+        depth = np.ascontiguousarray(depth)
+    if not depth.flags["ALIGNED"]:
+        log("    [WARN] Not aligned – copying")
+        depth = np.copy(depth)
+
+    return depth
+
+
+def save_depth_image(depth_np, output_path):
+    depth_cv = np.asarray(depth_np)
+    assert depth_cv.dtype == np.float32
+
+    depth_mm = np.nan_to_num(depth_cv, nan=0.0, posinf=0.0, neginf=0.0)
+    depth_mm = (depth_mm * 1000.0).astype(np.uint16)
+
+    if cv2.imwrite(output_path, depth_mm):
+        log("  • saved      :", output_path)
+    else:
+        log("  • save FAILED:", output_path)
+
+
+def process_bag(bag_path, topic_name, output_dir, process_one=False):
+    os.makedirs(output_dir, exist_ok=True)
+    frame_idx = 0
+
+    # First pass: count messages
+    with rosbag.Bag(bag_path, "r") as count_bag:
+        total_msgs = sum(1 for _ in count_bag.read_messages(topics=[topic_name]))
+
+    print(f"\nOpening bag: {bag_path}")
+    print(f"Topic: {topic_name}")
+    print(f"Messages to process: {total_msgs}")
+
+    # Second pass: process messages
+    with rosbag.Bag(bag_path, "r") as bag:
+        for topic, msg, t in tqdm(
+            bag.read_messages(topics=[topic_name]), total=total_msgs, desc="Decoding frames", unit="frame"
+        ):
+            try:
+                depth_np = decode_depth_message(msg)
+                output_path = os.path.join(output_dir, f"frame_{frame_idx:04d}.png")
+                save_depth_image(depth_np, output_path)
+            except Exception as exc:
+                print("  • ERROR      :", type(exc).__name__, exc)
+
+            frame_idx += 1
+            if process_one:
+                break
+
+    print("\nFinished – frames processed:", frame_idx)
+
+
+if __name__ == "__main__":
+    # bag_path = ("/home/tutuna/Videos/2024-11-14-13-45-37_heap_testsite/"
+    #             "2024-11-14-13-45-37_jetson_zed2i_depth.bag")
+
+    topic_name = "/boxi/zed2i/depth/image_raw/compressedDepth"
+
+    output_dir = os.path.join(os.environ["MISSION_DATA"], "zed2i_depth_frames")
+    os.makedirs(output_dir, exist_ok=True)
+
+    patterns = ["*_depth.bag"]
+    inputs = []
+    # Iterate through each output pattern to ensure it is located where its expected.
+    for pattern in patterns:
+        try:
+            f = get_bag(pattern=pattern, auto_download=False, rglob=False)
+            inputs.append(f)
+        except Exception as e:
+            print(e)
+
+    for bag_path in inputs:
+        process_bag(bag_path, topic_name, output_dir, process_one=False)

--- a/box_utils/box_binding/compressed_depth/CMakeLists.txt
+++ b/box_utils/box_binding/compressed_depth/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.18)
+project(compressed_depth LANGUAGES CXX)
+
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(nanobind CONFIG REQUIRED)
+
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+nanobind_add_module(_compressed_depth
+    src/binding.cpp
+    src/depth_rvl.cpp)
+
+target_include_directories(_compressed_depth PRIVATE
+    include
+    ${OpenCV_INCLUDE_DIRS})
+
+target_link_libraries(_compressed_depth PRIVATE ${OpenCV_LIBS})
+
+# put the .so inside the Python package directory
+install(TARGETS _compressed_depth LIBRARY DESTINATION compressed_depth)

--- a/box_utils/box_binding/compressed_depth/__init__.py
+++ b/box_utils/box_binding/compressed_depth/__init__.py
@@ -1,0 +1,12 @@
+# from importlib import import_module
+# _ext = import_module(__name__ + "._compressed_depth")
+# decode = _ext.decode
+# __all__ = ("decode",)
+from importlib import import_module
+
+# Correct: dynamic module is named _compressed_depth (with underscore)
+_ext = import_module("compressed_depth._compressed_depth")
+
+decode = _ext.decode
+
+__all__ = ("decode",)

--- a/box_utils/box_binding/compressed_depth/include/depth_rvl.hpp
+++ b/box_utils/box_binding/compressed_depth/include/depth_rvl.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <opencv2/core.hpp>
+#include <string>
+#include <vector>
+
+// Returns CV_32FC1 depth or throws std::runtime_error
+cv::Mat decode_depth(const std::string& encoding,
+                     const std::string& format_field,
+                     const std::vector<uint8_t>& payload);

--- a/box_utils/box_binding/compressed_depth/package.xml
+++ b/box_utils/box_binding/compressed_depth/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>compressed_depth</name>
+  <version>0.1.0</version>
+  <description>Python binding for ZED compressedDepth decoding</description>
+
+  <maintainer email="tutuna@leggedrobotics.com">Turcan Tuna</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>opencv</build_depend>
+  <build_export_depend>opencv</build_export_depend>
+  <exec_depend>opencv</exec_depend>
+
+  <!-- Optional -->
+  <export>
+  </export>
+</package>

--- a/box_utils/box_binding/compressed_depth/pyproject.toml
+++ b/box_utils/box_binding/compressed_depth/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["scikit-build-core>=0.6", "nanobind"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "compressed_depth"
+version = "0.1.0"
+description = "PNG / RVL depth decompression"
+requires-python = ">=3.8"
+
+[tool.scikit-build]
+# This tells scikit-build-core that your Python package lives in the
+# directory named “compressed_depth”.
+wheel.packages = ["compressed_depth"]
+
+# Editable-mode section REMOVED ─ default (out-of-tree) editable build
+# keeps CMake/Ninja artefacts in _skbuild/ instead of inside the package.

--- a/box_utils/box_binding/compressed_depth/src/binding.cpp
+++ b/box_utils/box_binding/compressed_depth/src/binding.cpp
@@ -1,0 +1,78 @@
+#include "depth_rvl.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+#include <opencv2/core.hpp>
+#include <vector>
+#include <cstring>
+#include <stdexcept>
+#include <iostream>
+
+namespace nb = nanobind;
+using nb::ndarray;
+
+ndarray<nb::numpy, float>
+decode(const ndarray<nb::numpy, nb::c_contig, uint8_t>& bytes,
+       const std::string& format_field,
+       const std::string& encoding = "32FC1")
+{
+    const size_t nbytes = bytes.size();
+    // std::fprintf(stderr, "[nb.decode] bytes=%zu  fmt=\"%s\"\n",
+    //              nbytes, format_field.c_str());
+
+    std::vector<uint8_t> payload(nbytes);
+    std::memcpy(payload.data(), bytes.data(), nbytes);
+
+    if (nbytes >= 20) {
+        uint32_t w = 0, h = 0;
+        std::memcpy(&w, payload.data() + 12, 4);
+        std::memcpy(&h, payload.data() + 16, 4);
+        // std::fprintf(stderr, "             RVL header: %ux%u\n", w, h);
+    }
+
+    cv::Mat depth;
+    try {
+        depth = decode_depth(encoding, format_field, payload);
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "[nb.decode] decode_depth() error: %s\n", e.what());
+        throw;
+    }
+
+    if (depth.empty() || depth.type() != CV_32FC1)
+        throw std::runtime_error("decode_depth() failed or returned wrong type");
+
+    /* ---- force copy to remove OpenCV internal alignment ------------------ */
+    depth = depth.clone();
+
+    /* ---- wrap into capsule-managed ndarray ------------------------------- */
+    auto* mat_ptr = new cv::Mat(std::move(depth));
+    nb::capsule owner(mat_ptr, [](void* p) noexcept {
+        delete static_cast<cv::Mat*>(p);
+    });
+
+    const size_t  shape[2]  = { static_cast<size_t>(mat_ptr->rows),
+                                static_cast<size_t>(mat_ptr->cols) };
+    const int64_t stride[2] = {
+        static_cast<int64_t>(mat_ptr->cols * sizeof(float)),  // row stride
+        static_cast<int64_t>(sizeof(float))                   // col stride
+    };
+
+    // std::fprintf(stderr, "             out shape  : %zux%zu\n", shape[0], shape[1]);
+
+    return nb::ndarray<nb::numpy, float>{
+        mat_ptr->data,
+        { static_cast<size_t>(mat_ptr->rows), static_cast<size_t>(mat_ptr->cols) },
+        owner
+    };
+    
+}
+
+NB_MODULE(_compressed_depth, m)
+{
+    m.doc() = "Depth decoder for RVL / PNG compressed depth images";
+    m.def("decode", &decode,
+          nb::arg("payload"),
+          nb::arg("format_field"),
+          nb::arg("encoding") = "32FC1");
+}

--- a/box_utils/box_binding/compressed_depth/src/depth_rvl.cpp
+++ b/box_utils/box_binding/compressed_depth/src/depth_rvl.cpp
@@ -1,0 +1,187 @@
+ #include "depth_rvl.hpp"
+
+ #include <opencv2/imgcodecs.hpp>
+ #include <opencv2/core/core.hpp>
+ #include <limits>
+ #include <cstring>
+ #include <stdexcept>
+ #include <vector>
+ #include <iostream>
+ #include <sstream>
+ 
+ // ---------- enable/disable very verbose logging here -----------------
+ #define RVL_DEBUG 0          // 0 = silent, 1 = high-level, 2 = per-loop
+ // ---------------------------------------------------------------------
+ 
+ static int* g_buffer;
+ static int* g_pBuffer;
+ static int  g_word;
+ static int  g_nibblesWritten;
+ 
+ static inline void RVL_DBG1(const std::string& s) { if constexpr (RVL_DEBUG >= 1) std::cerr << s << '\n'; }
+ static inline void RVL_DBG2(const std::string& s) { if constexpr (RVL_DEBUG >= 2) std::cerr << s << '\n'; }
+ 
+ static inline int DecodeVLE() {
+     unsigned int nibble;
+     int value = 0, bits = 29;
+     do {
+         if (!g_nibblesWritten) {
+             g_word = *g_pBuffer++;       // load word
+             g_nibblesWritten = 8;
+         }
+         nibble  = g_word & 0xf0000000;
+         value  |= (nibble << 1) >> bits;
+         g_word <<= 4;
+         g_nibblesWritten--;
+         bits -= 3;
+     } while (nibble & 0x80000000);
+     return value;
+ }
+ 
+ static inline void DecompressRVL(const unsigned char* input,
+                                  unsigned short*      output,
+                                  int                  numPixels)
+ {
+     g_buffer = g_pBuffer = (int*)input;
+     g_nibblesWritten = 0;
+ 
+     unsigned short current = 0, previous = 0;
+     int remaining = numPixels;
+ 
+     RVL_DBG2("[RVL]   starting decode loop, pixels=" + std::to_string(numPixels));
+ 
+     while (remaining) {
+         int zeros = DecodeVLE();
+         if (zeros > remaining)
+             throw std::runtime_error("RVL decode: zero-run exceeds bounds");
+ 
+         remaining -= zeros;
+         RVL_DBG2("        zeros = " + std::to_string(zeros));
+         for (; zeros; --zeros) *output++ = 0;
+ 
+         int nonzeros = DecodeVLE();
+         if (nonzeros > remaining)
+             throw std::runtime_error("RVL decode: non-zero run exceeds bounds");
+ 
+         remaining -= nonzeros;
+         RVL_DBG2("        nonzeros = " + std::to_string(nonzeros));
+ 
+         for (; nonzeros; --nonzeros) {
+             int positive = DecodeVLE();
+             int delta    = (positive >> 1) ^ -(positive & 1);
+             current      = previous + delta;
+             *output++    = current;
+             previous     = current;
+         }
+     }
+     RVL_DBG2("[RVL]   decode loop finished");
+ }
+ 
+ /* ---------- helpers --------------------------------------------------------- */
+ namespace {
+ 
+ int bitDepth(const std::string& enc) {
+     if (enc.rfind("32", 0) == 0) return 32;
+     if (enc.rfind("16", 0) == 0) return 16;
+     if (enc.rfind("8" , 0) == 0) return 8;
+     return -1;
+ }
+ 
+ std::string compressionFormatFrom(const std::string& field) {
+     if (field.empty()) return "png";
+     if (field.find("compressedDepth png") != std::string::npos) return "png";
+     if (field.find("compressedDepth rvl") != std::string::npos) return "rvl";
+     if (field.find("compressedDepth") != std::string::npos &&
+         field.find("compressedDepth ") == std::string::npos) return "png";
+     throw std::runtime_error("Unsupported compressedDepth format: " + field);
+ }
+ 
+ } // unnamed namespace
+ 
+ /* ---------- main decoder ---------------------------------------------------- */
+ cv::Mat decode_depth(const std::string& encoding,
+                      const std::string& format_field,
+                      const std::vector<uint8_t>& payload)
+ {
+     if (payload.empty())
+         throw std::runtime_error("decode_depth(): empty payload");
+ 
+     const std::string cfmt  = compressionFormatFrom(format_field);
+     const int bdepth        = bitDepth(encoding);
+ 
+     if (bdepth <= 0)
+         throw std::runtime_error("decode_depth(): unknown encoding \"" + encoding + '"');
+ 
+     RVL_DBG1("[decode]  fmt=\"" + cfmt + "\"  encoding=\"" + encoding + "\"  payload=" + std::to_string(payload.size()) + " B");
+ 
+     cv::Mat invDepth16;
+ 
+     /* ---------- PNG path --------------------------------------------------- */
+     if (cfmt == "png") {
+         try {
+             invDepth16 = cv::imdecode(payload, cv::IMREAD_UNCHANGED);
+         } catch (const cv::Exception& e) {
+             throw std::runtime_error("imdecode failed: " + std::string(e.what()));
+         }
+     }
+     /* ---------- RVL path --------------------------------------------------- */
+     else if (cfmt == "rvl") {
+         constexpr size_t header_offset = 12;              // ConfigHeader
+         if (payload.size() < header_offset + 8)
+             throw std::runtime_error("RVL payload too small");
+ 
+         const unsigned char* buf = payload.data() + header_offset;
+         uint32_t cols = 0, rows = 0;
+         std::memcpy(&cols, buf + 0, 4);
+         std::memcpy(&rows, buf + 4, 4);
+ 
+         RVL_DBG1("[decode]  RVL header  cols=" + std::to_string(cols) +
+                  " rows=" + std::to_string(rows));
+ 
+         if (cols == 0 || rows == 0)
+             throw std::runtime_error("RVL header has zero dimension");
+ 
+         const uint64_t numPix   = static_cast<uint64_t>(cols) * rows;
+         const size_t   rvl_size = payload.size() - header_offset;
+ 
+         if (numPix > std::numeric_limits<int>::max() ||
+             numPix * 2ULL > rvl_size * 10ULL)
+         {
+             std::ostringstream oss;
+             oss << "RVL sanity check failed: " << numPix
+                 << " pixels vs " << rvl_size << " bytes";
+             throw std::runtime_error(oss.str());
+         }
+ 
+         invDepth16 = cv::Mat(rows, cols, CV_16UC1);
+         DecompressRVL(buf + 8, invDepth16.ptr<unsigned short>(), rows * cols);
+     }
+     else {
+         throw std::runtime_error("decode_depth(): unknown compression \"" + cfmt + '"');
+     }
+ 
+     if (invDepth16.empty())
+         throw std::runtime_error("decode_depth(): decompression produced empty image");
+ 
+     RVL_DBG1("[decode]  decompressed OK → converting to float32");
+ 
+     /* ---------- inverse-depth → metres ------------------------------------ */
+     constexpr float depthZ0  = 100.0f;
+     constexpr float depthMax = 15.0f;
+     const float depthQuantA  = depthZ0 * (depthZ0 + 1.0f);
+     const float depthQuantB  = 1.0f - depthQuantA / depthMax;
+ 
+     cv::Mat depth32(invDepth16.rows, invDepth16.cols, CV_32FC1);
+     auto itOut = depth32.begin<float>();
+     auto itIn  = invDepth16.begin<unsigned short>();
+     for (; itOut != depth32.end<float>(); ++itOut, ++itIn) {
+         *itOut = (*itIn != 0)
+                   ? depthQuantA / (static_cast<float>(*itIn) - depthQuantB)
+                   : std::numeric_limits<float>::quiet_NaN();
+     }
+ 
+     RVL_DBG1("[decode]  finished (rows=" + std::to_string(depth32.rows) +
+              ", cols=" + std::to_string(depth32.cols) + ")");
+     return depth32;
+ }
+ 

--- a/box_utils/box_binding/compressed_depth/src/nanobind_impl.cpp
+++ b/box_utils/box_binding/compressed_depth/src/nanobind_impl.cpp
@@ -1,0 +1,8 @@
+/* src/nanobind_impl.cpp
+ *
+ * Single-translation-unit implementation of nanobind.
+ * This *must* be compiled exactly once per binary/module. */
+
+ #define NANOBIND_IMPLEMENTATION
+ #include <nanobind/nanobind.h>
+ 

--- a/box_utils/box_binding/decompress_zed2i.py
+++ b/box_utils/box_binding/decompress_zed2i.py
@@ -1,0 +1,104 @@
+import os
+import numpy as np
+import rosbag
+import cv2
+from tqdm import tqdm
+
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "box_binding")))
+import compressed_depth
+
+PRINT_VERBOSE = False
+
+
+def log(*args):
+    if PRINT_VERBOSE:
+        print(*args)
+
+
+def inspect_array(arr, label="array"):
+    if not PRINT_VERBOSE:
+        return
+    print(f"  • {label:<10} : shape={arr.shape}, dtype={arr.dtype}")
+    print(f"    ├ type      : {type(arr)}")
+    print(f"    ├ ndim      : {arr.ndim}")
+    print(f"    ├ itemsize  : {arr.itemsize}")
+    print(f"    ├ strides   : {arr.strides}")
+    print(f"    ├ size      : {arr.size}")
+    print(f"    ├ nbytes    : {arr.nbytes}")
+    print(f"    ├ flags     : {arr.flags}")
+    print(f"    └ first val : {arr.flat[0] if arr.size > 0 else 'n/a'}")
+
+
+def decode_depth_message(msg):
+    payload = np.frombuffer(msg.data, dtype=np.uint8).copy()
+    if payload.size < 20:
+        raise ValueError("Message too small (need 20+ bytes)")
+
+    header = payload[12:20]
+    cols, rows = np.frombuffer(header, dtype=np.uint32)
+    log(f"  • RVL header : {cols}×{rows}")
+
+    depth = compressed_depth.decode(payload, msg.format)
+    inspect_array(depth, "decoded")
+
+    if not depth.flags["C_CONTIGUOUS"]:
+        log("    [WARN] Not C-contiguous – copying")
+        depth = np.ascontiguousarray(depth)
+    if not depth.flags["ALIGNED"]:
+        log("    [WARN] Not aligned – copying")
+        depth = np.copy(depth)
+
+    return depth
+
+
+def save_depth_image(depth_np, output_path):
+    depth_cv = np.asarray(depth_np)
+    assert depth_cv.dtype == np.float32
+
+    depth_mm = np.nan_to_num(depth_cv, nan=0.0, posinf=0.0, neginf=0.0)
+    depth_mm = (depth_mm * 1000.0).astype(np.uint16)
+
+    if cv2.imwrite(output_path, depth_mm):
+        log("  • saved      :", output_path)
+    else:
+        log("  • save FAILED:", output_path)
+
+
+def process_bag(bag_path, topic_name, output_dir, process_one=False):
+    os.makedirs(output_dir, exist_ok=True)
+    frame_idx = 0
+
+    with rosbag.Bag(bag_path, "r") as count_bag:
+        total_msgs = sum(1 for _ in count_bag.read_messages(topics=[topic_name]))
+
+    print(f"\nOpening bag: {bag_path}")
+    print(f"Topic: {topic_name}")
+    print(f"Messages to process: {total_msgs}")
+
+    # Second pass: process messages
+    with rosbag.Bag(bag_path, "r") as bag:
+        for topic, msg, t in tqdm(
+            bag.read_messages(topics=[topic_name]), total=total_msgs, desc="Decoding frames", unit="frame"
+        ):
+            try:
+                depth_np = decode_depth_message(msg)
+                output_path = os.path.join(output_dir, f"frame_{frame_idx:04d}.png")
+                save_depth_image(depth_np, output_path)
+            except Exception as exc:
+                print("  • ERROR      :", type(exc).__name__, exc)
+
+            frame_idx += 1
+            if process_one:
+                break
+
+    print("\nFinished – frames processed:", frame_idx)
+
+
+if __name__ == "__main__":
+    bag_path = "/home/tutuna/Videos/2024-11-14-13-45-37_heap_testsite/" "2024-11-14-13-45-37_jetson_zed2i_depth.bag"
+
+    topic_name = "/boxi/zed2i/depth/image_raw/compressedDepth"
+
+    output_dir = "/home/tutuna/box_ws/src/grand_tour_box/box_utils/" "box_binding/zed2i_depth_frames"
+
+    process_bag(bag_path, topic_name, output_dir, process_one=False)

--- a/box_utils/box_binding/dummy.py
+++ b/box_utils/box_binding/dummy.py
@@ -1,0 +1,18 @@
+import sys
+import os
+import pathlib
+import inspect
+import numpy as np
+
+# Automatically add box_binding to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "box_binding")))
+
+import compressed_depth
+
+print("package dir :", pathlib.Path(inspect.getfile(compressed_depth)).parent)
+print("has decode  :", hasattr(compressed_depth, "decode"))
+
+try:
+    compressed_depth.decode(np.zeros(10, np.uint8), "compressedDepth rvl")
+except Exception as e:
+    print("decode ran :", type(e).__name__, e)


### PR DESCRIPTION
- adds the python binding to decompress RVL compressed depth images from rosbag to PNGs

Instructions:

- `git submodule update --init --recursive` we added a new submodule nanobind , it should be located in: "grand_tour_box/box_utils/box_binding/compressed_depth/external"
- `cd grand_tour_box/box_utils/box_binding/compressed_depth` 
- `pip install -e . --no-build-isolation --verbose`

Go to `grand_tour_box/box_utils/box_auto/python/box_auto/scripts/camera`

Set `MISSION_DATA` , `WS` variables, source the workspace for box_auto
run the script

The hacks that might be needed:

- If running within docker `D_PRELOAD=/usr/lib/x86_64-linux-gnu/libffi.so.7 python dummy.py`

- `pip3 install nanobind scikit-build-core`

