### PR TITLE
fixed sign of utc-gps time offset

### DIFF
--- a/box_utils/box_auto/python/box_auto/scripts/cpt7/export_raw_imu_bag.py
+++ b/box_utils/box_auto/python/box_auto/scripts/cpt7/export_raw_imu_bag.py
@@ -38,10 +38,10 @@ class RAWIMUDataParser:
         self.times = None
         self.expected_utc_offset = -18.0  # UTC time = GPS System Time + UTC offset
         self.expected_gps_offset = 0.0
-        self.weeks_to_seconds = 604_800.0
+        self.weeks_to_seconds = 604_800
         posix_start_in_utc = datetime(year=1970, month=1, day=1, hour=0, minute=0, second=0)
         gps_start_in_utc = datetime(year=1980, month=1, day=6, hour=0, minute=0, second=0)
-        self.gps_epoch_start_in_POSIX_seconds = (gps_start_in_utc - posix_start_in_utc).total_seconds()
+        self.gps_epoch_start_in_POSIX_seconds = int((gps_start_in_utc - posix_start_in_utc).total_seconds())
         self.x_accel = list()
         self.minusy_accel = list()
         self.z_accel = list()
@@ -83,15 +83,15 @@ class RAWIMUDataParser:
         else:
             self.logger.debug(f"IMU field name {imu_df.iloc[0, 0]} is correct {ColorLogger.GREEN_CHECK}")
         WEEK_INDEX = 4
-        SOW_INDEX = 5  # Seconds of week
-        week = imu_df.iloc[:, WEEK_INDEX]
+        week = imu_df.iloc[:, WEEK_INDEX].astype(int)
+        SOW_INDEX = 5
         seconds_of_week = imu_df.iloc[:, SOW_INDEX] - self.expected_gps_offset + self.expected_utc_offset
         ns_of_seconds_of_week = [int(round(int(math.modf(x)[0] * 1e9) / 1000, 0)) * 1000 for x in seconds_of_week]
         seconds_of_week_without_ns = seconds_of_week.astype(int)
         seconds_since_gps_start_in_utc = week * self.weeks_to_seconds + seconds_of_week_without_ns
         seconds_unix = seconds_since_gps_start_in_utc + self.gps_epoch_start_in_POSIX_seconds
         self.logger.info(f"Log time starts at {datetime.utcfromtimestamp(seconds_unix[0])}")
-        self.ros_times = [rospy.Time(secs=int(x), nsecs=y) for x, y in zip(seconds_unix, ns_of_seconds_of_week)]
+        self.ros_times = [rospy.Time(secs=x, nsecs=y) for x, y in zip(seconds_unix, ns_of_seconds_of_week)]
 
     def load_imu_data(self, imu_df: pd.DataFrame):
         """

--- a/box_utils/boxi/boxi/set_cpt7_time.py
+++ b/box_utils/boxi/boxi/set_cpt7_time.py
@@ -26,7 +26,7 @@ def set_internet_time():
     gps_epoch_start = datetime.datetime(1980, 1, 6, 0, 0, 0)
 
     print(response.tx_time)
-    delta_seconds = response.tx_time - datetime.datetime.timestamp(gps_epoch_start) - 18 - 3600
+    delta_seconds = response.tx_time - datetime.datetime.timestamp(gps_epoch_start) + 18 - 3600
     gps_weeks = int(delta_seconds / 604800)  # 604800 seconds in a GPS week
     gps_seconds = delta_seconds % 604800  # 18 leap seconds since 1980
     return gps_weeks, gps_seconds
@@ -38,7 +38,7 @@ def set_local_pc_time():
     # Calculate the current GPS week and seconds since the start of GPS epoch (January 6, 1980 00:00:00 UTC)
     gps_epoch_start = datetime.datetime(1980, 1, 6, 0, 0, 0)
 
-    delta_seconds = now - datetime.datetime.timestamp(gps_epoch_start) - 18 - 3600
+    delta_seconds = now - datetime.datetime.timestamp(gps_epoch_start) + 18 - 3600
     gps_weeks = int(delta_seconds / 604800)  # 604800 seconds in a GPS week
     gps_seconds = delta_seconds % 604800  # 18 leap seconds since 1980
     return gps_weeks, gps_seconds


### PR DESCRIPTION
When setting the CPT7 time with the local time, we are currently subtracting 18 seconds. I.e. we set UTC_time = GPS_time - 18 when it should be + 18.

An issue arises in the post-processing of the raw CPT7 IMU data where an extra -18 seconds are offset (correctly I believe)  at https://github.com/leggedrobotics/grand_tour_box/blob/b7929202922bea9a5d7d4510b038570617e07f5c/box_utils/box_auto/python/box_auto/scripts/cpt7/export_raw_imu_bag.py#L39 leading to a 36 second offset w.r.t. the other IMUs.

Thus datasets recorded to this point are 36 seconds offset, and in the post-processing should be corrected the other way.

Newer datasets will not have this problem.

Also this magic 18 number MIGHT change next year :)